### PR TITLE
Remove focus on close button

### DIFF
--- a/capplets/keyboard/mate-keyboard-properties-dialog.ui
+++ b/capplets/keyboard/mate-keyboard-properties-dialog.ui
@@ -140,7 +140,6 @@
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="has-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="has-default">True</property>
                 <property name="receives-default">False</property>


### PR DESCRIPTION
This restore focus on first notebook tab title.

Help https://github.com/mate-desktop/mate-control-center/issues/785
Tested by rebuilding Mate 1.26 Debian source package.